### PR TITLE
ci: CBPL guardrail hard-fail

### DIFF
--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -1,0 +1,38 @@
+name: guardrails
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - master
+      - cleanup/prune-non-cbpl
+
+concurrency:
+  group: guardrails-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guardrails:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      
+      - name: Connectors registry guardrails
+        run: |
+          if [ -f app/shared/connectorsRegistry.v1.json ]; then
+            node tools/connectors-registry-test.js
+          else
+            echo "::warning::connectorsRegistry.v1.json missing on this ref; skipping registry guardrail."
+          fi
+
+      - name: CBPL guardrails
+        run: |
+          test -f app/server/services/payloadService.js || (echo "::error::payloadService.js missing on this ref" && exit 1)
+          node tools/cbpl-guardrails-test.js


### PR DESCRIPTION
Flip CBPL step from warn+skip to hard-fail on missing payloadService.js. Registry remains warn+skip.